### PR TITLE
Adding activerecord support and some small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+console

--- a/README.md
+++ b/README.md
@@ -52,25 +52,24 @@ end
 
 ## Usage
 
-1. In the class associated with the image invoke `mount_engine' method
+1. In the class that has the original image url, invoke `mount_imagizer_engine' method. This method takes two parameters: the image name and the method to be called to get the original url of the image.
 
-This method takes a single parameter that defines an image prefix
-
-```
+```ruby
 class User
-
-  mount_engine :profile_image
-
+  extend ImagizerEngine::Mount #this line is not necessary if you're using Rails with ActiveRecord 
+  mount_imagizer_engine :profile_image, :original_url_method_name
+  
 end
 ```
 
-2. With the `profile_image` prefix you will need to define a `profile_image_original_url` method in your class. This method should define the original url of the image.
-```
+2. Since we passed `original_url_method_name` as the method which contains the full image url, we should define it somehow. It can be a column if using on Rails/ActiveRecord for instance, or simply define:
+```ruby
 class User
 
-  def profile_image_original_url
-    "path/to/file"
+  def original_url_method_name
+    "http://s3aws.address/my_original_image.png"
   end
+end
 ```
 
 3. To use the Imagizer Engine use the `profile_image_url()` method. This also takes an optional parameter that could be one of the versions defined in the config file

--- a/imagizer_engine.gemspec
+++ b/imagizer_engine.gemspec
@@ -21,5 +21,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pg"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rails", ">= 4.0.0"
+
 end

--- a/lib/imagizer_engine.rb
+++ b/lib/imagizer_engine.rb
@@ -51,5 +51,18 @@ module ImagizerEngine
 
 end
 
-require "imagizer_engine/url"
+if defined?(Rails)
 
+  module ImagizerEngine
+    class Railtie < Rails::Railtie
+      
+      initializer "imagizer_engine.active_record" do
+        ActiveSupport.on_load :active_record do
+          require 'imagizer_engine/orm/activerecord'
+        end
+      end
+    end
+  end
+end
+
+require "imagizer_engine/url"

--- a/lib/imagizer_engine/mount.rb
+++ b/lib/imagizer_engine/mount.rb
@@ -1,22 +1,12 @@
 module ImagizerEngine
   module Mount
-    def mount_engine(column)
-      mod = Module.new
-      include mod
-      mod.class_eval <<-RUBY, __FILE__, __LINE__+1
+    def mount_imagizer_engine(column, original_url_method)
 
-        def #{column}_url(version=nil)
-          raise NoMethodError, "define `#{column}_original_url' for #{self.inspect}" unless respond_to?(:#{column}_original_url)
-          to_imagizer_url(((#{column}_original_url)), version)         
-        end
+      self.send(:define_method, "#{column}_url") do |version=nil|
+        raise NoMethodError, "there's no instance method called #{original_url_method}" unless respond_to?(original_url_method)
+        ImagizerEngine::Url.new.to_url(self.send(original_url_method), version)
+      end
 
-        private
-
-        def to_imagizer_url(url, version)
-          Url.new.to_url(url, version)          
-        end
-        
-      RUBY
-    end    
+    end
   end
 end

--- a/lib/imagizer_engine/orm/activerecord.rb
+++ b/lib/imagizer_engine/orm/activerecord.rb
@@ -1,0 +1,12 @@
+require 'active_record'
+
+module ImagizerEngine
+  module ActiveRecord
+
+    include ImagizerEngine::Mount
+
+
+  end # ActiveRecord
+end # ImagizerEngine
+
+ActiveRecord::Base.extend ImagizerEngine::ActiveRecord

--- a/lib/imagizer_engine/version.rb
+++ b/lib/imagizer_engine/version.rb
@@ -1,3 +1,3 @@
 module ImagizerEngine
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/spec/imagizer_engine_spec.rb
+++ b/spec/imagizer_engine_spec.rb
@@ -6,8 +6,8 @@ describe ImagizerEngine do
     @class = Class.new
     @class.send(:extend, ImagizerEngine::Mount)
 
-    @class.mount_engine(:image)
-    @class.mount_engine(:cover)
+    @class.mount_imagizer_engine(:image, :image_original_url)
+    @class.mount_imagizer_engine(:cover, :image_original_url)
     @instance = @class.new
     @instance.define_singleton_method(:image_original_url) do
       "path/to/file.png"
@@ -46,7 +46,9 @@ describe ImagizerEngine do
   end
 
   it "should raise error if `cover_original_url is not defined" do
-    expect{@instance.cover_url}.to raise_error(NoMethodError)
+    @class.mount_imagizer_engine(:main, :undefined_method)
+    instance = @class.new
+    expect{instance.main_url}.to raise_error(NoMethodError)
   end
 
   it "should have `_url method defined" do

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'support/activerecord'
+
+def create_table(name)
+  ActiveRecord::Base.connection.create_table(name, force: true) do |t|
+    t.column :image, :string
+    t.column :images, :json
+    t.column :textfile, :string
+    t.column :textfiles, :json
+    t.column :foo, :string
+  end
+end
+
+def drop_table(name)
+  ActiveRecord::Base.connection.drop_table(name)
+end
+
+def reset_class(class_name)
+  Object.send(:remove_const, class_name) rescue nil
+  Object.const_set(class_name, Class.new(ActiveRecord::Base))
+end
+
+describe ImagizerEngine::ActiveRecord do
+  before(:all) { create_table("artworks") }
+  after(:all) { drop_table("artworks") }
+
+  before do
+    reset_class("Artwork")
+    Artwork.class_eval do 
+      mount_imagizer_engine :main_image, :my_original_image_url 
+
+      def my_original_image_url
+        "path/to/file.png"
+      end
+    end
+    @artwork = Artwork.new
+  end
+
+  after do
+    Artwork.delete_all
+  end
+
+  describe("ImagizerEngine::Mount") do 
+    
+    it "should respond to main_image_url" do
+      expect(@artwork).to respond_to(:main_image_url)
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
+require 'bundler'
 require 'imagizer_engine'
+require 'pry'

--- a/spec/support/activerecord.rb
+++ b/spec/support/activerecord.rb
@@ -1,0 +1,30 @@
+if RUBY_ENGINE == 'jruby'
+  require 'activerecord-jdbcpostgresql-adapter'
+else
+  require 'pg'
+end
+require 'active_record'
+require 'imagizer_engine/orm/activerecord'
+Bundler.require
+
+# Change this if PG is unavailable
+dbconfig = {
+  :adapter  => 'postgresql',
+  :database => 'imagizer_engine_test',
+  :encoding => 'utf8'
+}
+
+database = dbconfig.delete(:database)
+
+ActiveRecord::Base.establish_connection(dbconfig.merge(database: "template1"))
+begin
+  ActiveRecord::Base.connection.create_database database
+rescue ActiveRecord::StatementInvalid => e # database already exists
+end
+ActiveRecord::Base.establish_connection(dbconfig.merge(:database => database))
+
+ActiveRecord::Migration.verbose = false
+
+if ActiveRecord::VERSION::STRING >= '4.2'
+  ActiveRecord::Base.raise_in_transactional_callbacks = true
+end


### PR DESCRIPTION
Hey @sfkaos, I did 3 main changes here:

1-  Remove the necessity of calling `extend ImagizerEngine::ActiveRecord` when using the gem with Rails/ActiveRecord

2- Changed the name from `mount_engine` to `mount_imagizer_engine` (since you don't extend the class anymore, it could cause some confusion about which engine the user is really mounting, so this name makes more sense.

3- The user have the ability to pass the method where to get the original image URL like this:

``` ruby
class User
  mount_imagizer_engine :profile_image, :original_url_method_name
end
```

That's useful because the column where he stores the original url can have any name (or can be a custom method as well).
